### PR TITLE
Release windows versions of provider

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
     needs: [ "test", "get-tag-name" ]
     strategy:
       matrix:
-        goos: [ "linux", "darwin" ]
+        goos: [ "linux", "darwin", "windows" ]
         goarch: [ "amd64", "arm64" ]
     steps:
       - name: setup


### PR DESCRIPTION
I would like to use this provider on a widows machine. Having had a brief look at the project I could not see any obvious reason as to why a windows provider could not compile or run.

The binary does compile with `GOOS=windows`. I have yet to test it thoroughly when used at runtime.